### PR TITLE
Revert "Bump markdown-it-py from 2.2.0 to 3.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ gitdb==4.0.10
 GitPython==3.1.31
 gunicorn==20.1.0
 kombu==5.3.0
-markdown-it-py==3.0.0
+markdown-it-py==2.2.0
 mccabe==0.7.0
 mdurl==0.1.2
 pbr==5.11.1


### PR DESCRIPTION
Reverts prplecake/remote-ac-controller#222